### PR TITLE
fixed crash if used layer+search without zoom

### DIFF
--- a/frontend/src/components/Map/Map.jsx
+++ b/frontend/src/components/Map/Map.jsx
@@ -90,6 +90,9 @@ export default class Map extends React.Component {
 
 	componentDidUpdate() {
 		if (this.props.coordinates) {
+			this.map.eachLayer((layer) => {
+				this.map.removeLayer(layer);
+			});
 			this.map.remove();
 			this.map = L.map('map');
 			this.map.setView(new L.LatLng(this.props.coordinates[0], this.props.coordinates[1]), 8);


### PR DESCRIPTION
this should fix the crash if there was a selected custom layer and a new search is made. Needs testing on other platforms to see if issue is resolved